### PR TITLE
common: move ro.telephony.default_network to device

### DIFF
--- a/vendor_prop.mk
+++ b/vendor_prop.mk
@@ -51,7 +51,6 @@ PRODUCT_PROPERTY_OVERRIDES += \
 PRODUCT_PROPERTY_OVERRIDES += \
     rild.libpath=/vendor/lib64/libril-qc-qmi-1.so \
     ril.subscription.types=NV,RUIM \
-    ro.telephony.default_network=10 \
     telephony.lteOnCdmaDevice=1
 
 # Enable netmgr


### PR DESCRIPTION
* we support single and dualsim devices, those need different values

Change-Id: Ic603bf31253d91bdf8be2ee8522750cdc812e241